### PR TITLE
1.9.4 (2020-01-03T14:20Z):

### DIFF
--- a/advancedfx/__init__.py
+++ b/advancedfx/__init__.py
@@ -3,7 +3,7 @@ import bpy
 bl_info = {
 	"name": "advancedfx Blender Scripts",
 	"author": "advancedfx.org",
-	"version": (1, 9, 2),
+	"version": (1, 9, 4),
 	"blender": (2, 80, 0),
 	"location": "File > Import/Export",
 	"description": "For inter-operation with HLAE.",

--- a/advancedfx/import_agr.py
+++ b/advancedfx/import_agr.py
@@ -21,6 +21,7 @@ class SmdImporterEx(vs_import_smd.SmdImporter):
 	bl_idname = "advancedfx.smd_importer_ex"
 	
 	smd = None
+	bSkipPhysics = False
 
 	# Properties used by the file browser
 	filepath : bpy.props.StringProperty(name="File Path", description="File filepath used for importing the SMD/VTA/DMX/QC file", maxlen=1024, default="", options={'HIDDEN'})
@@ -57,6 +58,12 @@ class SmdImporterEx(vs_import_smd.SmdImporter):
 		if GAgrImporter.onlyBones:
 			return
 		super(SmdImporterEx, self).readShapes()
+        
+	def readSMD(self, filepath, upAxis, rotMode, newscene = False, smd_type = None, target_layer = 0):
+		if SmdImporterEx.bSkipPhysics and smd_type == vs_utils.PHYS:
+			return 0
+		else:
+			return super().readSMD(filepath, upAxis, rotMode, newscene, smd_type, target_layer) # call parent method
 
 
 def ReadString(file):
@@ -289,10 +296,10 @@ class AgrImporter(bpy.types.Operator, vs_utils.Logger):
 		default=False,
 	)
 	
-	noPhysics: bpy.props.BoolProperty(
-		name="Remove useless meshes",
-		description="Removes Physics and smd_bone_vis for faster workflow.",
-		default=True
+	bSkipPhysics: bpy.props.BoolProperty(
+		name="Skip Physic Meshes",
+		description="Skips the import of physic (collision) meshes if the .qc contains them.",
+		default = True
 	)
 
 	onlyBones: bpy.props.BoolProperty(
@@ -332,24 +339,6 @@ class AgrImporter(bpy.types.Operator, vs_utils.Logger):
 	def invoke(self, context, event):
 		bpy.context.window_manager.fileselect_add(self)
 		return {'RUNNING_MODAL'}
-	
-	def Physicsr(self):
-			for i in bpy.data.objects: 
-		# Delete smd_bone_vis
-				if i.name.find("smd_bone_vis") != -1:
-					bpy.data.objects.remove(i)
-				
-			for i in bpy.data.objects: 
-		# Delete physics objects
-				if i.name.find("physics") != -1:
-					bpy.data.objects.remove(i)
-       
-			for i in bpy.data.collections: 
-		# Delete physics collections
-				if i.name.find("physics") != -1:
-					bpy.data.collections.remove(i)
-					
-			return {'TEST'}
 	
 	def addCurvesToModel(self, context, modelData):
 		
@@ -467,6 +456,7 @@ class AgrImporter(bpy.types.Operator, vs_utils.Logger):
 			filePath = filePath + "/" + os.path.basename(filePath) + ".qc"
 			filePath = filePath.replace("/", "\\")
 			
+			SmdImporterEx.bSkipPhysics = self.bSkipPhysics
 			GAgrImporter.smd = None
 			GAgrImporter.onlyBones = self.onlyBones
 			modelData = None
@@ -474,8 +464,11 @@ class AgrImporter(bpy.types.Operator, vs_utils.Logger):
 			try:
 				bpy.ops.advancedfx.smd_importer_ex(filepath=filePath, doAnim=False)
 				modelData = ModelData(GAgrImporter.smd)
-			except:
-				self.error("Failed to import \""+filePath+"\".")
+			except Exception as e:
+				if '?.qc' in str(e):
+					pass
+				else:
+					self.error("Failed to import \""+filePath+"\".")
 				return None
 			finally:
 				GAgrImporter.smd = None
@@ -491,11 +484,6 @@ class AgrImporter(bpy.types.Operator, vs_utils.Logger):
 			for bone in armature.pose.bones:
 				if bone.rotation_mode != 'QUATERNION':
 					bone.rotation_mode = 'QUATERNION'
-
-			# noPhysics:
-			# thanks to Darkhandrob for letting Devostated know how blind he is
-			if self.noPhysics:
-				self.Physicsr()
 						
 			# Scale:
 			

--- a/advancedfx/readme.txt
+++ b/advancedfx/readme.txt
@@ -56,10 +56,17 @@ Blender doesn't support proper interpolation of curves for quaternions yet.
 
 Changelog:
 
+1.9.4 (2020-01-03T14:20Z):
+- Removed "Remove useless meshes" option (by Devostated)
+- Added "Skip Physic Meshes" option, enabled by default (by Devostated)
+- Removed irritating missing ?.qc Error (by Devostated)
+- Test with Blender Source Tools 3.0.3.
+- Test with Blender Source Tools 2.81a.
+
 1.9.2 (2020-01-03T10:31Z):
 - Added option for model instancing (faster), enabled by default.
-- Tested with Blender Source Tools 3.0.3.
-- Tested with Blender 2.81a.
+- Test with Blender Source Tools 3.0.3.
+- Test with Blender Source Tools 2.81a.
 
 1.8.0 (2019-08-30T06:28Z):
 - Added option "Remove useless meshes" (Removes Physics and smd_bone_vis for faster workflow.) (by Devostated).


### PR DESCRIPTION
1.9.4 (2020-01-03T14:20Z):
- Removed "Remove useless meshes" option (by Devostated)
- Added "Skip Physic Meshes" option, enabled by default (by Devostated)
- Removed irritating missing ?.qc Error (by Devostated)
- Test with Blender Source Tools 3.0.3.
- Test with Blender Source Tools 2.81a.