### PR TITLE
Increase AGR performance

### DIFF
--- a/advancedfx/import_agr.py
+++ b/advancedfx/import_agr.py
@@ -221,6 +221,7 @@ class ModelHandle:
 		self.modelData = False
 		self.lastRenderOrigin = None
 		self.lastRenderRotQuat = None
+		self.boneLastRenderRotQuats = {}
 
 		# We are lazy, so we use frame 0 to set as not visible (initially) / hide_render 1:
 		self.visibilityFrames = [0, 1]
@@ -823,20 +824,29 @@ class AgrImporter(bpy.types.Operator, vs_utils.Logger):
 									
 									bone.matrix = matrix
 									
+									renderRotQuat = bone.rotation_quaternion.copy()
+									
+									# make sure we take the shortest path:
+									if i in modelHandle.boneLastRenderRotQuats:
+										dot = modelHandle.boneLastRenderRotQuats[i].dot(renderRotQuat)
+										if dot < 0:
+											renderRotQuat.negate()
+									modelHandle.boneLastRenderRotQuats[i] = renderRotQuat
+									
 									#vs_utils.select_only( modelData.smd.a )
 									
 									if self.interKey:
 										afx_utils.AppendInterKeys_Location(currentTime, bone.location, modelHandle.boneLocationXFrames[i], modelHandle.boneLocationYFrames[i], modelHandle.boneLocationZFrames[i])
-										afx_utils.AppendInterKeys_Rotation(currentTime, bone.rotation_quaternion, modelHandle.boneRotationWFrames[i], modelHandle.boneRotationXFrames[i], modelHandle.boneRotationYFrames[i], modelHandle.boneRotationZFrames[i])
+										afx_utils.AppendInterKeys_Rotation(currentTime, renderRotQuat, modelHandle.boneRotationWFrames[i], modelHandle.boneRotationXFrames[i], modelHandle.boneRotationYFrames[i], modelHandle.boneRotationZFrames[i])
 									
 									modelHandle.boneLocationXFrames[i].extend((currentTime, bone.location.x))
 									modelHandle.boneLocationYFrames[i].extend((currentTime, bone.location.y))
 									modelHandle.boneLocationZFrames[i].extend((currentTime, bone.location.z))
 									
-									modelHandle.boneRotationWFrames[i].extend((currentTime, bone.rotation_quaternion.w))
-									modelHandle.boneRotationXFrames[i].extend((currentTime, bone.rotation_quaternion.x))
-									modelHandle.boneRotationYFrames[i].extend((currentTime, bone.rotation_quaternion.y))
-									modelHandle.boneRotationZFrames[i].extend((currentTime, bone.rotation_quaternion.z))
+									modelHandle.boneRotationWFrames[i].extend((currentTime, renderRotQuat.w))
+									modelHandle.boneRotationXFrames[i].extend((currentTime, renderRotQuat.x))
+									modelHandle.boneRotationYFrames[i].extend((currentTime, renderRotQuat.y))
+									modelHandle.boneRotationZFrames[i].extend((currentTime, renderRotQuat.z))
 					
 					dict.Peekaboo(file,'/')
 					

--- a/advancedfx/import_agr.py
+++ b/advancedfx/import_agr.py
@@ -342,6 +342,17 @@ class AgrImporter(bpy.types.Operator, vs_utils.Logger):
 		description="Objects with same model are instanced, animation data is separate and modifiers duplicated (faster). Recommended to disable it for beginners, who want to export it to other 3D application",
 		default=True)
 	
+	keyframeInterpolation: bpy.props.EnumProperty(
+		name="Keyframe interpolation",
+		description="Constant recommended for beginners. Advanced users can choose Bezier for significantly faster import times.",
+		items=[
+			('CONSTANT', "Constant (recommended)", "No interpolation"),
+			('LINEAR', "Linear", "Linear interpolation"),
+			('BEZIER', "Bezier (fast import)", "Smooth interpolation"),
+		],
+		default='CONSTANT'
+	)
+	
 	# class properties
 	valveMatrixToBlender = mathutils.Matrix.Rotation(math.pi/2,4,'Z')
 	blenderCamUpQuat = mathutils.Quaternion((math.cos(0.5 * math.radians(90.0)), math.sin(0.5* math.radians(90.0)), 0.0, 0.0))
@@ -932,22 +943,22 @@ class AgrImporter(bpy.types.Operator, vs_utils.Logger):
 					continue
 				curves = modelHandle.modelData.curves
 				afx_utils.AddKeysList_Visible(curves[0].keyframe_points, modelHandle.visibilityFrames)
-				afx_utils.AddKeysList_Location(curves[1].keyframe_points, curves[2].keyframe_points, curves[3].keyframe_points, modelHandle.locationXFrames, modelHandle.locationYFrames, modelHandle.locationZFrames)
-				afx_utils.AddKeysList_Rotation(curves[4].keyframe_points, curves[5].keyframe_points, curves[6].keyframe_points, curves[7].keyframe_points, modelHandle.rotationWFrames, modelHandle.rotationXFrames, modelHandle.rotationYFrames, modelHandle.rotationZFrames)
+				afx_utils.AddKeysList_Location(self.keyframeInterpolation, curves[1].keyframe_points, curves[2].keyframe_points, curves[3].keyframe_points, modelHandle.locationXFrames, modelHandle.locationYFrames, modelHandle.locationZFrames)
+				afx_utils.AddKeysList_Rotation(self.keyframeInterpolation, curves[4].keyframe_points, curves[5].keyframe_points, curves[6].keyframe_points, curves[7].keyframe_points, modelHandle.rotationWFrames, modelHandle.rotationXFrames, modelHandle.rotationYFrames, modelHandle.rotationZFrames)
 				updateImportProgress(len(modelHandle.visibilityFrames) + len(modelHandle.locationXFrames) * 3 + len(modelHandle.rotationWFrames) * 4)
 				for i in modelHandle.boneLocationXFrames:
-					afx_utils.AddKeysList_Location(curves[7*i+8].keyframe_points, curves[7*i+9].keyframe_points, curves[7*i+10].keyframe_points, modelHandle.boneLocationXFrames[i], modelHandle.boneLocationYFrames[i], modelHandle.boneLocationZFrames[i])
+					afx_utils.AddKeysList_Location(self.keyframeInterpolation, curves[7*i+8].keyframe_points, curves[7*i+9].keyframe_points, curves[7*i+10].keyframe_points, modelHandle.boneLocationXFrames[i], modelHandle.boneLocationYFrames[i], modelHandle.boneLocationZFrames[i])
 					updateImportProgress(len(modelHandle.boneLocationXFrames[i]) * 3)
 				for i in modelHandle.boneRotationWFrames:
-					afx_utils.AddKeysList_Rotation(curves[7*i+11].keyframe_points, curves[7*i+12].keyframe_points, curves[7*i+13].keyframe_points, curves[7*i+14].keyframe_points, modelHandle.boneRotationWFrames[i], modelHandle.boneRotationXFrames[i], modelHandle.boneRotationYFrames[i], modelHandle.boneRotationZFrames[i])
+					afx_utils.AddKeysList_Rotation(self.keyframeInterpolation, curves[7*i+11].keyframe_points, curves[7*i+12].keyframe_points, curves[7*i+13].keyframe_points, curves[7*i+14].keyframe_points, modelHandle.boneRotationWFrames[i], modelHandle.boneRotationXFrames[i], modelHandle.boneRotationYFrames[i], modelHandle.boneRotationZFrames[i])
 					updateImportProgress(len(modelHandle.boneRotationWFrames[i]) * 4)
 				for curve in curves:
 					curve.update()
 			if camData is not None:
 				curves = camData.curves
-				afx_utils.AddKeysList_Location(curves[0].keyframe_points, curves[1].keyframe_points, curves[2].keyframe_points, camData.locationXFrames, camData.locationYFrames, camData.locationZFrames)
-				afx_utils.AddKeysList_Rotation(curves[3].keyframe_points, curves[4].keyframe_points, curves[5].keyframe_points, curves[6].keyframe_points, camData.rotationWFrames, camData.rotationXFrames, camData.rotationYFrames, camData.rotationZFrames)
-				afx_utils.AddKeysList_Value(curves[7].keyframe_points, camData.lensFrames)
+				afx_utils.AddKeysList_Location(self.keyframeInterpolation, curves[0].keyframe_points, curves[1].keyframe_points, curves[2].keyframe_points, camData.locationXFrames, camData.locationYFrames, camData.locationZFrames)
+				afx_utils.AddKeysList_Rotation(self.keyframeInterpolation, curves[3].keyframe_points, curves[4].keyframe_points, curves[5].keyframe_points, curves[6].keyframe_points, camData.rotationWFrames, camData.rotationXFrames, camData.rotationYFrames, camData.rotationZFrames)
+				afx_utils.AddKeysList_Value(self.keyframeInterpolation, curves[7].keyframe_points, camData.lensFrames)
 				updateImportProgress(len(camData.locationXFrames) * 3 + len(camData.rotationWFrames) * 4 + len(camData.lensFrames))
 				for curve in curves:
 					curve.update()

--- a/advancedfx/import_agr.py
+++ b/advancedfx/import_agr.py
@@ -946,12 +946,16 @@ class AgrImporter(bpy.types.Operator, vs_utils.Logger):
 				afx_utils.AddKeysList_Location(self.keyframeInterpolation, curves[1].keyframe_points, curves[2].keyframe_points, curves[3].keyframe_points, modelHandle.locationXFrames, modelHandle.locationYFrames, modelHandle.locationZFrames)
 				afx_utils.AddKeysList_Rotation(self.keyframeInterpolation, curves[4].keyframe_points, curves[5].keyframe_points, curves[6].keyframe_points, curves[7].keyframe_points, modelHandle.rotationWFrames, modelHandle.rotationXFrames, modelHandle.rotationYFrames, modelHandle.rotationZFrames)
 				updateImportProgress(len(modelHandle.visibilityFrames) + len(modelHandle.locationXFrames) * 3 + len(modelHandle.rotationWFrames) * 4)
+				currentFrames = 0
 				for i in modelHandle.boneLocationXFrames:
 					afx_utils.AddKeysList_Location(self.keyframeInterpolation, curves[7*i+8].keyframe_points, curves[7*i+9].keyframe_points, curves[7*i+10].keyframe_points, modelHandle.boneLocationXFrames[i], modelHandle.boneLocationYFrames[i], modelHandle.boneLocationZFrames[i])
-					updateImportProgress(len(modelHandle.boneLocationXFrames[i]) * 3)
+					currentFrames += len(modelHandle.boneLocationXFrames[i]) * 3
+				updateImportProgress(currentFrames)
+				currentFrames = 0
 				for i in modelHandle.boneRotationWFrames:
 					afx_utils.AddKeysList_Rotation(self.keyframeInterpolation, curves[7*i+11].keyframe_points, curves[7*i+12].keyframe_points, curves[7*i+13].keyframe_points, curves[7*i+14].keyframe_points, modelHandle.boneRotationWFrames[i], modelHandle.boneRotationXFrames[i], modelHandle.boneRotationYFrames[i], modelHandle.boneRotationZFrames[i])
-					updateImportProgress(len(modelHandle.boneRotationWFrames[i]) * 4)
+					currentFrames += len(modelHandle.boneRotationWFrames[i]) * 4
+				updateImportProgress(currentFrames)
 				for curve in curves:
 					curve.update()
 			if camData is not None:

--- a/advancedfx/utils.py
+++ b/advancedfx/utils.py
@@ -52,6 +52,22 @@ def AddKey_Value(interKey, keyframe_points, time, value):
 	item.co = [time, value]
 	item.interpolation = 'CONSTANT'
 
+def AddKeysList_Value(keyframe_points, data):
+	keyframe_points.add(len(data) // 2)
+	keyframe_points.foreach_set("co", data)
+	for item in keyframe_points:
+		item.interpolation = 'CONSTANT'
+
+def AppendInterKeys_Value(time, value, data):
+	if 0 == len(data):
+		return
+	lastValue = data[-1]
+	lastTime = data[-2]
+	for interTime in GetInterKeyRange(lastTime, time):
+		dT = (interTime-lastTime) / (time-lastTime)
+		interValue = lastValue * (1.0 - dT) + value * dT
+		data.extend((interTime, interValue))
+
 def AddKey_Visible(interKey, keyframe_points_hide_render, time, visible):
 	if(interKey and 0 < len(keyframe_points_hide_render)):
 		lastItem = keyframe_points_hide_render[-1]
@@ -68,6 +84,20 @@ def AddKey_Visible(interKey, keyframe_points_hide_render, time, visible):
 	item = keyframe_points_hide_render[-1]
 	item.co = [time, 0.0 if( visible ) else 1.0]
 	item.interpolation = 'CONSTANT'
+
+def AddKeysList_Visible(keyframe_points, data):
+	keyframe_points.add(len(data) // 2)
+	keyframe_points.foreach_set("co", data)
+	for item in keyframe_points:
+		item.interpolation = 'CONSTANT'
+
+def AppendInterKeys_Visible(time, invisible, data):
+	if 0 == len(data):
+		return
+	lastInvisible = data[-1]
+	lastTime = data[-2]
+	for interTime in GetInterKeyRange(lastTime, time):
+		data.extend((interTime, 0 if lastInvisible == 0 and invisible == 0 else 1))
 
 def AddKey_Location(interKey, keyframe_points_location_x, keyframe_points_location_y, keyframe_points_location_z, time, location):
 	if(interKey and 0 < len(keyframe_points_location_x) and 0 < len(keyframe_points_location_y) and 0 < len(keyframe_points_location_z)):
@@ -105,6 +135,34 @@ def AddKey_Location(interKey, keyframe_points_location_x, keyframe_points_locati
 	itemY.interpolation = 'CONSTANT'
 	itemZ.interpolation = 'CONSTANT'
 	
+def AddKeysList_Location(keyframe_points_x, keyframe_points_y, keyframe_points_z, data_x, data_y, data_z):
+	keyframe_points_x.add(len(data_x) // 2)
+	keyframe_points_x.foreach_set("co", data_x)
+	for item in keyframe_points_x:
+		item.interpolation = 'CONSTANT'
+	keyframe_points_y.add(len(data_y) // 2)
+	keyframe_points_y.foreach_set("co", data_y)
+	for item in keyframe_points_y:
+		item.interpolation = 'CONSTANT'
+	keyframe_points_z.add(len(data_z) // 2)
+	keyframe_points_z.foreach_set("co", data_z)
+	for item in keyframe_points_z:
+		item.interpolation = 'CONSTANT'
+
+def AppendInterKeys_Location(time, location, data_x, data_y, data_z):
+	if 0 == len(data_x):
+		return
+	lastX = data_x[-1]
+	lastY = data_y[-1]
+	lastZ = data_z[-1]
+	lastTime = data_x[-2]
+	lastLocation = mathutils.Vector((lastX, lastY, lastZ))
+	for interTime in GetInterKeyRange(lastTime, time):
+		interLocation = lastLocation.lerp(location, (interTime-lastTime) / (time-lastTime))
+		data_x.extend((interTime, interLocation.x))
+		data_y.extend((interTime, interLocation.y))
+		data_z.extend((interTime, interLocation.z))
+
 def AddKey_Scale(interKey, keyframe_points_scale_x, keyframe_points_scale_y, keyframe_points_scale_z, time, scale):
 	AddKey_Location(interKey, keyframe_points_scale_x, keyframe_points_scale_y, keyframe_points_scale_z, time, scale)
 
@@ -153,3 +211,36 @@ def AddKey_Rotation(interKey, keyframe_points_rotation_quaternion_w, keyframe_po
 	itemY.interpolation = 'CONSTANT'
 	itemZ.interpolation = 'CONSTANT'
 
+def AddKeysList_Rotation(keyframe_points_w, keyframe_points_x, keyframe_points_y, keyframe_points_z, data_w, data_x, data_y, data_z):
+	keyframe_points_w.add(len(data_w) // 2)
+	keyframe_points_w.foreach_set("co", data_w)
+	for item in keyframe_points_w:
+		item.interpolation = 'CONSTANT'
+	keyframe_points_x.add(len(data_x) // 2)
+	keyframe_points_x.foreach_set("co", data_x)
+	for item in keyframe_points_x:
+		item.interpolation = 'CONSTANT'
+	keyframe_points_y.add(len(data_y) // 2)
+	keyframe_points_y.foreach_set("co", data_y)
+	for item in keyframe_points_y:
+		item.interpolation = 'CONSTANT'
+	keyframe_points_z.add(len(data_z) // 2)
+	keyframe_points_z.foreach_set("co", data_z)
+	for item in keyframe_points_z:
+		item.interpolation = 'CONSTANT'
+
+def AppendInterKeys_Rotation(time, rotation, data_w, data_x, data_y, data_z):
+	if 0 == len(data_w):
+		return
+	lastW = data_w[-1]
+	lastX = data_x[-1]
+	lastY = data_y[-1]
+	lastZ = data_z[-1]
+	lastTime = data_w[-2]
+	lastRotation = mathutils.Quaternion((lastW, lastX, lastY, lastZ))
+	for interTime in GetInterKeyRange(lastTime, time):
+		interRotation = lastRotation.slerp(rotation, (interTime-lastTime) / (time-lastTime))
+		data_w.extend((interTime, interRotation.w))
+		data_x.extend((interTime, interRotation.x))
+		data_y.extend((interTime, interRotation.y))
+		data_z.extend((interTime, interRotation.z))

--- a/advancedfx/utils.py
+++ b/advancedfx/utils.py
@@ -52,11 +52,12 @@ def AddKey_Value(interKey, keyframe_points, time, value):
 	item.co = [time, value]
 	item.interpolation = 'CONSTANT'
 
-def AddKeysList_Value(keyframe_points, data):
+def AddKeysList_Value(interpolation, keyframe_points, data):
 	keyframe_points.add(len(data) // 2)
 	keyframe_points.foreach_set("co", data)
-	for item in keyframe_points:
-		item.interpolation = 'CONSTANT'
+	if keyframe_points[0].interpolation != interpolation:
+		for item in keyframe_points:
+			item.interpolation = interpolation
 
 def AppendInterKeys_Value(time, value, data):
 	if 0 == len(data):
@@ -135,19 +136,20 @@ def AddKey_Location(interKey, keyframe_points_location_x, keyframe_points_locati
 	itemY.interpolation = 'CONSTANT'
 	itemZ.interpolation = 'CONSTANT'
 	
-def AddKeysList_Location(keyframe_points_x, keyframe_points_y, keyframe_points_z, data_x, data_y, data_z):
+def AddKeysList_Location(interpolation, keyframe_points_x, keyframe_points_y, keyframe_points_z, data_x, data_y, data_z):
 	keyframe_points_x.add(len(data_x) // 2)
 	keyframe_points_x.foreach_set("co", data_x)
-	for item in keyframe_points_x:
-		item.interpolation = 'CONSTANT'
 	keyframe_points_y.add(len(data_y) // 2)
 	keyframe_points_y.foreach_set("co", data_y)
-	for item in keyframe_points_y:
-		item.interpolation = 'CONSTANT'
 	keyframe_points_z.add(len(data_z) // 2)
 	keyframe_points_z.foreach_set("co", data_z)
-	for item in keyframe_points_z:
-		item.interpolation = 'CONSTANT'
+	if keyframe_points_x[0].interpolation != interpolation:
+		for item in keyframe_points_x:
+			item.interpolation = interpolation
+		for item in keyframe_points_y:
+			item.interpolation = interpolation
+		for item in keyframe_points_z:
+			item.interpolation = interpolation
 
 def AppendInterKeys_Location(time, location, data_x, data_y, data_z):
 	if 0 == len(data_x):
@@ -211,23 +213,24 @@ def AddKey_Rotation(interKey, keyframe_points_rotation_quaternion_w, keyframe_po
 	itemY.interpolation = 'CONSTANT'
 	itemZ.interpolation = 'CONSTANT'
 
-def AddKeysList_Rotation(keyframe_points_w, keyframe_points_x, keyframe_points_y, keyframe_points_z, data_w, data_x, data_y, data_z):
+def AddKeysList_Rotation(interpolation, keyframe_points_w, keyframe_points_x, keyframe_points_y, keyframe_points_z, data_w, data_x, data_y, data_z):
 	keyframe_points_w.add(len(data_w) // 2)
 	keyframe_points_w.foreach_set("co", data_w)
-	for item in keyframe_points_w:
-		item.interpolation = 'CONSTANT'
 	keyframe_points_x.add(len(data_x) // 2)
 	keyframe_points_x.foreach_set("co", data_x)
-	for item in keyframe_points_x:
-		item.interpolation = 'CONSTANT'
 	keyframe_points_y.add(len(data_y) // 2)
 	keyframe_points_y.foreach_set("co", data_y)
-	for item in keyframe_points_y:
-		item.interpolation = 'CONSTANT'
 	keyframe_points_z.add(len(data_z) // 2)
 	keyframe_points_z.foreach_set("co", data_z)
-	for item in keyframe_points_z:
-		item.interpolation = 'CONSTANT'
+	if keyframe_points_w[0].interpolation != interpolation:
+		for item in keyframe_points_w:
+			item.interpolation = interpolation
+		for item in keyframe_points_x:
+			item.interpolation = interpolation
+		for item in keyframe_points_y:
+			item.interpolation = interpolation
+		for item in keyframe_points_z:
+			item.interpolation = interpolation
 
 def AppendInterKeys_Rotation(time, rotation, data_w, data_x, data_y, data_z):
 	if 0 == len(data_w):


### PR DESCRIPTION
The current individual keyframe adding is very slow when there are a lot of keyframes.

With these changes they are all read into memory and added at once using Blender's fast native methods.

However, setting the interpolation mode is not possible using fast native methods, so I also made it selectable. If the user selects the Blender's default interpolation mode (Bezier), we don't need to implicitly set the interpolation mode, which makes the import even faster.

I also implemented the shortest rotation path taking for bones too, since the lack of it might become an issue with interpolation enabled.

Here are some import time comparisons:

AGR Size | Current release | Fork, default interpolation | Fork, Bezier interpolation
---------- | ----------------- | ---------------------------- | ------------------------------
20 MB     | 103.8334 s         | 82.5832 s                           | 49.0030 s
80 MB     | 8879.9433 s       | 1332.9248 s                       | 424.8857 s