### PR TITLE
Fix BST becoming unusable after using AGR importer

### DIFF
--- a/advancedfx/import_agr.py
+++ b/advancedfx/import_agr.py
@@ -365,10 +365,12 @@ class AgrImporter(bpy.types.Operator, vs_utils.Logger):
 		time_start = time.time()
 		result = None
 		try:
+			bpy.utils.unregister_class(vs_import_smd.SmdImporter)
 			bpy.utils.register_class(SmdImporterEx)
 			result = self.readAgr(context)
 		finally:
 			bpy.utils.unregister_class(SmdImporterEx)
+			bpy.utils.register_class(vs_import_smd.SmdImporter)
 		
 		for area in context.screen.areas:
 			if area.type == 'VIEW_3D':

--- a/advancedfx/readme.txt
+++ b/advancedfx/readme.txt
@@ -19,13 +19,6 @@ options!
 
 
 
-Known problems:
-
-Using the AGR Import menu entry causes the Blender Source Tools import menu
-entry not to function anymore until you restart Blender!
-
-
-
 Usage:
 
 Always make sure to select the correct render properties in your project first


### PR DESCRIPTION
Now you don't need to restart Blender anymore if you want to use BST after importing an AGR.