### PR TITLE
1.12.5 (2020-04-28T21:03Z):

### DIFF
--- a/advancedfx/__init__.py
+++ b/advancedfx/__init__.py
@@ -3,7 +3,7 @@ import bpy
 bl_info = {
 	"name": "advancedfx Blender Scripts",
 	"author": "advancedfx.org",
-	"version": (1, 12, 2),
+	"version": (1, 12, 5),
 	"blender": (2, 80, 0),
 	"location": "File > Import/Export",
 	"description": "For inter-operation with HLAE.",

--- a/advancedfx/export_agr2fbx.py
+++ b/advancedfx/export_agr2fbx.py
@@ -27,9 +27,9 @@ class AgrExport(bpy.types.Operator, vs_utils.Logger):
 	global_scale: bpy.props.FloatProperty(
 		name="Scale",
 		description="Scale everything by this value (0.01 default, 0.0254 is more accurate)",
-		min=0.000001, max=1000000.0,
-		soft_min=0.001, soft_max=1.0,
-		default=0.01,
+		min=0.000001, max=100000.0,
+		soft_min=0.1, soft_max=10.0,
+		default=1,
 	)
 
 	root_name: bpy.props.StringProperty(
@@ -68,7 +68,7 @@ class AgrExport(bpy.types.Operator, vs_utils.Logger):
 					CurrentChildren.select_set(1)
 				# rename top to root
 				CurrentObjectName = CurrentModel.name
-				CurrentModel.name = "root"
+				CurrentModel.name = self.root_name
 				# export single objects as fbx
 				fullfiles = self.filepath + "/" + CurrentObjectName + ".fbx"
 				if self.skip_meshes:
@@ -100,6 +100,8 @@ class AgrExport(bpy.types.Operator, vs_utils.Logger):
 			if any(CameraData.name.startswith(c) for c in ("afxCam", "camera")):
 				# select camera
 				CameraData.select_set(1)
+				# scale camera
+				bpy.ops.transform.resize(value=(0.01, 0.01, 0.01))
 				# export single cameras as fbx
 				fullfiles = self.filepath + "/" + CameraData.name + ".fbx"
 				bpy.ops.export_scene.fbx(
@@ -110,6 +112,7 @@ class AgrExport(bpy.types.Operator, vs_utils.Logger):
 					bake_anim_use_all_actions = False, 
 					bake_anim_simplify_factor = 0)
 				# undo all changes
+				bpy.ops.transform.resize(value=(100, 100, 100))
 				CameraData.select_set(0)
 
 		print("FBX-Export script finished in %.4f sec." % (time.time() - time_start))

--- a/advancedfx/export_bvh.py
+++ b/advancedfx/export_bvh.py
@@ -36,7 +36,6 @@ class BvhExporter(bpy.types.Operator, vs_utils.Logger):
 	
 	# Properties used by the file browser
 	filepath: bpy.props.StringProperty(subtype="FILE_PATH")
-	filename_ext: ".bvh"
 	filter_glob: bpy.props.StringProperty(default="*.bvh", options={'HIDDEN'})
 
 	# Custom properties

--- a/advancedfx/export_cam.py
+++ b/advancedfx/export_cam.py
@@ -27,7 +27,6 @@ class CamExporter(bpy.types.Operator, vs_utils.Logger):
 	
 	# Properties used by the file browser
 	filepath: bpy.props.StringProperty(subtype="FILE_PATH")
-	filename_ext: ".cam"
 	filter_glob: bpy.props.StringProperty(default="*.cam", options={'HIDDEN'})
 
 	# Custom properties

--- a/advancedfx/import_agr.py
+++ b/advancedfx/import_agr.py
@@ -300,7 +300,6 @@ class AgrImporter(bpy.types.Operator, vs_utils.Logger):
 	
 	# Properties used by the file browser
 	filepath: bpy.props.StringProperty(subtype="FILE_PATH")
-	filename_ext: ".agr"
 	filter_glob: bpy.props.StringProperty(default="*.agr", options={'HIDDEN'})
 
 	# Custom properties	

--- a/advancedfx/import_bvh.py
+++ b/advancedfx/import_bvh.py
@@ -130,7 +130,6 @@ class BvhImporter(bpy.types.Operator, vs_utils.Logger):
 	
 	# Properties used by the file browser
 	filepath: bpy.props.StringProperty(subtype="FILE_PATH")
-	filename_ext: ".bvh"
 	filter_glob: bpy.props.StringProperty(default="*.bvh", options={'HIDDEN'})
 
 	# Custom properties

--- a/advancedfx/import_cam.py
+++ b/advancedfx/import_cam.py
@@ -43,7 +43,6 @@ class CamImporter(bpy.types.Operator, vs_utils.Logger):
 	
 	# Properties used by the file browser
 	filepath: bpy.props.StringProperty(subtype="FILE_PATH")
-	filename_ext: ".cam"
 	filter_glob: bpy.props.StringProperty(default="*.cam", options={'HIDDEN'})
 
 	# Custom properties

--- a/advancedfx/readme.txt
+++ b/advancedfx/readme.txt
@@ -50,6 +50,11 @@ For more informations visit it's Advancedfx Wiki page ( https://github.com/advan
 
 Changelog:
 
+1.12.5 (2020-04-28T21:03Z):
+- added support for Blender 3.0 Alpha
+- fixed changing Root Bone Name
+- fixed camera scale export
+
 1.12.2 (2020-03-13T13:35Z):
 - Fixed camera FOV not being animated porperly.
 


### PR DESCRIPTION
- added support for Blender 3.0 Alpha
- fixed changing Root Bone Name
- fixed camera scale export